### PR TITLE
Fix redirections

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -6,14 +6,10 @@ upstream {{ php_base_name }} {
 
 {% for item in php_redirections %}
 server {
+    listen 80;
+    listen 443 ssl;
     server_name {{ item }};
     return 301 $scheme://{{ php_domain_name }}$request_uri;
-
-    {% if ssl_config_file.stat.exists -%}
-    include {{ ssl_config_file.stat.path }};
-    {%- else %}
-    include snippets/snakeoil.conf;
-    {%- endif %}
 }
 {% endfor %}
 


### PR DESCRIPTION
when redirecting with a 301, no need to read the content of the
request, so no need of ssl certificate

also, we need to listen 443 ssl.